### PR TITLE
change namespace from Monero to MoneroPHP, re-add imports, & use classes

### DIFF
--- a/example.php
+++ b/example.php
@@ -5,9 +5,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-use Monero\jsonRPCClient;
-use Monero\daemonRPC;
-use Monero\walletRPC;
+require_once('src/daemonRPC.php');
+use MoneroPHP\daemonRPC;
 
 $daemonRPC = new daemonRPC('127.0.0.1', 28081); // Change to match your daemon (monerod) IP address and port; 18081 is the default port for mainnet, 28081 for testnet, 38081 for stagenet
 $getblockcount = $daemonRPC->getblockcount();
@@ -25,6 +24,8 @@ $get_info = $daemonRPC->get_info();
 // $setbans = $daemonRPC->setbans('8.8.8.8');
 // $getbans = $daemonRPC->getbans();
 
+require_once('src/walletRPC.php');
+use MoneroPHP\walletRPC;
 
 $walletRPC = new walletRPC('127.0.0.1', 28083); // Change to match your wallet (monero-wallet-rpc) IP address and port; 18083 is the customary port for mainnet, 28083 for testnet, 38083 for stagenet
 $create_wallet = $walletRPC->create_wallet('monero_wallet', ''); // Creates a new wallet named monero_wallet with no passphrase.  Comment this line and edit the next line to use your own wallet

--- a/src/SHA3.php
+++ b/src/SHA3.php
@@ -1,7 +1,4 @@
-<?php /* -*- coding: utf-8; indent-tabs-mode: t; tab-width: 4 -*-
-vim: ts=4 noet ai */
-namespace Monero;
-
+<?php
 /**
 	Streamable SHA-3 for PHP 5.2+, with no lib/ext dependencies!
 
@@ -23,7 +20,7 @@ namespace Monero;
 	@license LGPL-3+
 	@file
 */
-
+namespace MoneroPHP;
 
 /**
 	SHA-3 (FIPS-202) for PHP strings (byte arrays) (PHP 5.2.1+)

--- a/src/base58.php
+++ b/src/base58.php
@@ -1,6 +1,5 @@
 <?php
-
-namespace Monero;
+namespace MoneroPHP;
 
 /**
  *

--- a/src/cryptonote.php
+++ b/src/cryptonote.php
@@ -1,13 +1,12 @@
 <?php
-
-namespace Monero;
 /*
 Copyright (c) 2018 Monero-Integrations
 */
+namespace MoneroPHP;
 
-use Monero\base58 as base58;
-use Monero\SHA3 as SHA3;
-use Monero\ed25519 as ed25519;
+use MoneroPHP\base58;
+use MoneroPHP\SHA3;
+use MoneroPHP\ed25519;
 
 
     class Cryptonote

--- a/src/daemonRPC.php
+++ b/src/daemonRPC.php
@@ -1,6 +1,4 @@
 <?php
-namespace Monero;
-
 /**
  *
  * monerophp/daemonRPC
@@ -31,8 +29,10 @@ namespace Monero;
  * $block = $daemonRPC->getblock_by_height(1);
  *
  */
+namespace MoneroPHP;
 
-use Monero\jsonRPCClient as jsonRPCClient;
+require_once('jsonRPCClient.php'); 
+use MoneroPHP\jsonRPCClient;
 
 class daemonRPC
 {

--- a/src/ed25519.php
+++ b/src/ed25519.php
@@ -1,7 +1,5 @@
 <?php
-namespace Monero;
-
-/*
+/**
  * The MIT License (MIT)
  * 
  * Copyright (c) 2013 John Judy
@@ -23,6 +21,7 @@ namespace Monero;
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+namespace MoneroPHP;
 
 //ini_set('xdebug.max_nesting_level', 0);
 /**

--- a/src/jsonRPCClient.php
+++ b/src/jsonRPCClient.php
@@ -1,7 +1,4 @@
 <?php
-
-namespace Monero;
-
 /**
  * jsonRPCClient.php
  *
@@ -11,6 +8,8 @@ namespace Monero;
  * @author Kacper Rowinski <krowinski@implix.com>
  * http://implix.com
  */
+namespace MoneroPHP;
+
 class jsonRPCClient
 {
     protected $url = null, $is_debug = false, $parameters_structure = 'array'; 
@@ -166,7 +165,7 @@ class jsonRPCClient
     {
         if ($pFailed)
         {
-            throw new RuntimeException($pErrMsg);
+            throw new \RuntimeException($pErrMsg);
         }
     }
     

--- a/src/walletRPC.php
+++ b/src/walletRPC.php
@@ -1,6 +1,4 @@
 <?php
-namespace Monero;
-
 /**
  *
  * monerophp/walletRPC
@@ -30,9 +28,10 @@ namespace Monero;
  * $signed = $walletRPC->sign('The Times 03/Jan/2009 Chancellor on brink of second bailout for banks');
  *
  */
+namespace MoneroPHP;
 
-
-use Monero\jsonRPCClient as jsonRPCClient;
+require_once('jsonRPCClient.php'); 
+use MoneroPHP\jsonRPCClient;
 
 class walletRPC
 {


### PR DESCRIPTION
the namespace should probably be MoneroPHP, not just Monero, in order to be more precise about the scope of this library

the `use` keyword doesn't import anything unless you have an IDE that autoloads--most vanilla servers do not, thus imports must be explicit (must retain `require_once(...)`)

classes need not be used `as` anything

this is tested working